### PR TITLE
Fix iter loader and batch size

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,13 +18,13 @@ def MNIST_loaders(train_batch_size=50000, test_batch_size=10000):
         MNIST('./data/', train=True,
               download=True,
               transform=transform),
-        batch_size=5000, shuffle=True)
+        batch_size=train_batch_size, shuffle=True)
 
     test_loader = DataLoader(
         MNIST('./data/', train=False,
               download=True,
               transform=transform),
-        batch_size=10000, shuffle=False)
+        batch_size=test_batch_size, shuffle=False)
 
     return train_loader, test_loader
 

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     train_loader, test_loader = MNIST_loaders()
 
     net = Net([784, 500, 500])
-    x, y = iter(train_loader).next()
+    x, y = next(iter(train_loader))
     x, y = x.cuda(), y.cuda()
     x_pos = overlay_y_on_x(x, y)
     rnd = torch.randperm(x.size(0))
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     print('train error:', 1.0 - net.predict(x).eq(y).float().mean().item())
 
-    x_te, y_te = iter(test_loader).next()
+    x_te, y_te = next(iter(test_loader))
     x_te, y_te = x_te.cuda(), y_te.cuda()
 
     print('test error:', 1.0 - net.predict(x_te).eq(y_te).float().mean().item())


### PR DESCRIPTION
Got this error

```
Traceback (most recent call last):
  File "main.py", line 102, in <module>
    x, y = iter(train_loader).next()
AttributeError: '_SingleProcessDataLoaderIter' object has no attribute 'next'
```

This could be due to pytorch versions. But this fix should generalize across versions.

Also, fixed the batch size to use provided arguments. Training was performed on batch size of 5000 instead of 50000. Not sure if that was intentional.

Batch size of 50000 decreases both train and test error.

```
train error: 0.06754004955291748
test error: 0.06840002536773682
```