### PR TITLE
Changed the shuffle method

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,8 +114,10 @@ if __name__ == "__main__":
     x, y = next(iter(train_loader))
     x, y = x.cuda(), y.cuda()
     x_pos = overlay_y_on_x(x, y)
-    rnd = torch.randperm(x.size(0))
-    x_neg = overlay_y_on_x(x, y[rnd])
+    rand_mask = torch.randint(0, 9, y.size()).cuda()
+    y_rnd = (y + rand_mask + 1) % 10
+
+    x_neg = overlay_y_on_x(x, y_rnd)
     
     for data, name in zip([x, x_pos, x_neg], ['orig', 'pos', 'neg']):
         visualize_sample(data, name)


### PR DESCRIPTION
The current method for creating x_neg shuffles the indices for labels and re-distributes them. However, this method lefts roughly 10% of labels unchanged, and hence 10% of x_neg pics are actually the 'good' samples.

I attempted to solve this problem by introducing a mask layer that contains random ints from 1 to 9, adding it to the original y data, and finding the remainder of 10. This ensures that the new distribution is i.i.d (as randint is i.i.d) and no more unchanged values after the shuffle.